### PR TITLE
Assert the repo's remote url is the same as configured

### DIFF
--- a/cd_manager/models.py
+++ b/cd_manager/models.py
@@ -40,6 +40,11 @@ class Package(models.Model):
                 assert not repo.bare
                 remote = repo.remote("origin")
                 assert remote.exists()
+                matched_url = None
+                for url in remote.urls:
+                    if url == self.repo_url:
+                        matched_url = url
+                assert matched_url
                 remote.pull()
             except AssertionError:
                 redownload()


### PR DESCRIPTION
Otherwise redownload the repo.

As the remote URL can be configured in the CI admin view changes done there should also reflect inside the build operation. This adds a check whether the (local) repo's remote URL matches the one configured and if not also triggers a redownload. This came up when migrating `ros-melodic-rosparam-shortcuts` to the CI/CD architecture.