### PR TITLE
Fix recursion & makedepend-check

### DIFF
--- a/cd_manager/alpm.py
+++ b/cd_manager/alpm.py
@@ -35,19 +35,19 @@ class ALPMHelper:
             srcinfo = SRCINFO(srcinfo_path)
             if rundeps:
                 deps += srcinfo.getrundeps()
-            elif makedeps:
+            if makedeps:
                 deps += srcinfo.getmakedeps()
-            elif checkdeps:
+            if checkdeps:
                 deps += srcinfo.getcheckdeps()
         else:
             pkg = self.get_pkg_from_syncdbs(pkgname=pkgname)
             if rundeps:
                 deps += pkg.depends
-            elif makedeps:
+            if makedeps:
                 deps += pkg.makedepends
-            elif checkdeps:
+            if checkdeps:
                 deps += pkg.checkdepends
-        return deps
+        return list(set(deps))
 
 
 class PackageNotFoundError(RuntimeError):

--- a/cd_manager/models.py
+++ b/cd_manager/models.py
@@ -103,7 +103,7 @@ class Package(models.Model):
         return built_packages
 
     def rebuildtree(self, built_packages=[]):
-        self.build(force_rebuild=True, build_packages=built_packages)
+        self.build(force_rebuild=True, built_packages=built_packages)
 
     def push_to_aur(self):
         path = os.path.join(

--- a/cd_manager/tests.py
+++ b/cd_manager/tests.py
@@ -1,3 +1,31 @@
 from django.test import TestCase
+from cd_manager.models import Package
+from cd_manager.alpm import ALPMHelper, PackageNotFoundError
+from cd_manager.recursion_helper import Recursionlimit
 
-# Create your tests here.
+# Prototype implementation for Package.build() to check the visitor does the job
+def get_deps(pkgname, level=0, visited=[]):
+    if pkgname in visited:
+        return
+    visited.append(pkgname)
+    try:
+        deps = ALPMHelper().get_deps(pkgname=pkgname, rundeps=True, makedeps=True)
+    except PackageNotFoundError as err:
+        print(" "*level + str(err))
+        return
+    print(" "*level + pkgname + " has " + str(len(deps)) + " dependencies.")
+
+    with Recursionlimit(2000):
+        for dep in deps:
+            dep = Package.sanitize_dep(dep)
+            get_deps(dep, level+1, visited)
+
+class TestRecursiveDeps(TestCase):
+
+    # A ROS package with very minimal depencencies
+    def test_ros_melodic_genmsg(self):
+        get_deps("ros-melodic-genmsg")
+
+    # A ROS package with a lot of dependencies
+    def test_ros_melodic_desktop_full(self):
+        get_deps("ros-melodic-desktop-full")


### PR DESCRIPTION
As the dependency graph is not necessarily acyclic we have to make sure to check each node
only once. Otherwise this might end up in an endless loop (meaning we will hit the recursion limit). To avoid this, we can record the packages we have already built, as the names are unique. This was already implemented for `rebuildtree`, but not for `build`.

I've added a test that uses a simplified version of the depth-first search (might be a good idea to refactor out the actual search function, let me know if this is desired) that shows that doing a dep-search on `ros-melodic-desktop-full` does work fast.

I refactored the `rebuildtree` and `build` functions into one function, as I didn't see a reason to double the code there. It could probably be changed everywhere where `rebuildtree` gets called, but as both actions are available in the view, it might be good to have the function in the model explicitly.

Also, the way the alpm helper was written, combining of depends, makedepends and checkdepends was not possible, but they were checked hierarchically. I guess, this was not intentional, also given the use of this function e.g. [here](https://github.com/bionade24/abs_cd/blob/master/cd_manager/models.py#L79). This lead to build errors due to missing packages if building a package make-depending on other unbuilt packages.