### PR TITLE
Make sure Build() always returns the built_packages array

### DIFF
--- a/cd_manager/models.py
+++ b/cd_manager/models.py
@@ -79,7 +79,7 @@ class Package(models.Model):
         # only once. Otherwise this might end up in an endless loop (meaning we will hit the
         # recursion limit)
         if self.name in built_packages:
-            return
+            return built_packages
         built_packages.append(self.name)
 
         self.repo_status_check()


### PR DESCRIPTION
When a cyclic dependency was hit, the array of built packages was not returned leading it to be `NoneType` in the calling function.