### PR TITLE
Switch to archlinux/archlinux docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/archlinux/base:latest
+FROM docker.io/archlinux/archlinux:latest
 LABEL org.abs-cd=webcd_manager
 RUN pacman --noconfirm -Sy archlinux-keyring && pacman-key --init && pacman-key --populate archlinux
 RUN systemd-machine-id-setup

--- a/makepkg/docker/Dockerfile
+++ b/makepkg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/archlinux/base:latest
+FROM docker.io/archlinux/archlinux:latest
 LABEL org.abs-cd.tools=makepkg
 RUN pacman --noconfirm -Sy archlinux-keyring && pacman-key --init && pacman-key --populate archlinux
 RUN systemd-machine-id-setup


### PR DESCRIPTION
archlinux/base seems to have been deprecated, one should use archlinux/archlinux now.

See https://hub.docker.com/r/archlinux/base/