### PR TITLE
makepkg: Make docker ressource constraints configurable.

### DIFF
--- a/abs_cd/settings.py
+++ b/abs_cd/settings.py
@@ -154,9 +154,15 @@ PKGBUILDREPOS_PATH = "/var/packages"
 PKGBUILDREPOS_HOST_PATH = helper.get_setting('PKGBUILDREPOS_HOST_PATH', '/var/local/abs_cd/packages')
 PACMAN_CONFIG_PATH = "/etc/pacman.conf"
 PACMANREPO_PATH = "/repo"
+
+# Set the following settings via the settings.ini
 PACMANREPO_HOST_PATH = helper.get_setting('PACMANREPO_HOST_PATH', 'Docker-volume')
 PACMANDB_FILENAME = helper.get_setting('PACMANREPO_NAME', "abs_cd-local") + ".db.tar.zst"
 PACMAN_FILESDB_FILENAME = helper.get_setting('PACMANREPO_NAME', "abs_cd-local") + ".files.tar.zst"
+
+D_MEM_LIMIT = helper.get_setting('BUILDCONTAINER_MEMORY_LIMIT', '8G')
+D_SWAP_LIMIT = helper.get_setting('BUILDCONTAINER_SWAP_LIMIT', '8G')
+D_CPU_SHARES = int(helper.get_setting('BUILDCONTAINER_CPU_SHARES', '128'))
 
 LOGGING = {
     'version': 1,

--- a/makepkg/makepkg.py
+++ b/makepkg/makepkg.py
@@ -65,7 +65,8 @@ class PackageSystem:
             container_name = f'mkpkg_{pkgbase.name}_{datetime.now().microsecond}'
             container_output = \
                 Connection().containers.run(image=BUILDCONT_IMG, command=(makepkg_args),
-                                            remove=False, mem_limit='8G', memswap_limit='8G', cpu_shares=128,
+                                            remove=False, mem_limit=settings.D_MEM_LIMIT, memswap_limit=settings.D_SWAP_LIMIT,
+                                            cpu_shares=settings.D_CPU_SHARES,
                                             volumes={os.path.join(settings.PKGBUILDREPOS_HOST_PATH, pkgbase.name):
                                                      {'bind': '/src', 'mode': 'ro'},
                                                      get_pacmanrepo_host_path():

--- a/settings.ini.template
+++ b/settings.ini.template
@@ -6,3 +6,6 @@ docker_socket = unix://var/run/docker.sock
 pkgbuildrepos_host_path = /var/local/abs_cd/packages
 pacmanrepo_host_path = Docker-volume
 pacmanrepo_name = abs_cd-local
+buildcontainer_memory_limit = 8G
+buildcontainer_swap_limit = 8G
+buildcontainer_cpu_shares = 128


### PR DESCRIPTION
Memory, swap and cpu shares limits exposed by docker aren't hardcoded any longer and are now configurable in settings.ini